### PR TITLE
[HAPI-57] Block nil result and code gardening

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -211,14 +211,14 @@ func BenchmarkRun1Cached(b *testing.B) {
 	}
 }
 
-func BenchmarkRun10(b *testing.B) {
+func BenchmarkRun4(b *testing.B) {
 	raw, _ := ioutil.ReadFile("./test/tc1.json")
 
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var ruleRaw RuleRaw
 	json.Unmarshal(raw, &ruleRaw)
 
-	c.Worker = 10
+	c.Worker = 4
 	e := New(c)
 	e.SetRules(ruleRaw.Data)
 	f := make(map[string]interface{})
@@ -231,14 +231,14 @@ func BenchmarkRun10(b *testing.B) {
 	}
 }
 
-func BenchmarkRun10Cached(b *testing.B) {
+func BenchmarkRun4Cached(b *testing.B) {
 	raw, _ := ioutil.ReadFile("./test/tc1.json")
 
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var ruleRaw RuleRaw
 	json.Unmarshal(raw, &ruleRaw)
 
-	c.Worker = 10
+	c.Worker = 4
 	c.Cache = true
 	e := New(c)
 	e.SetRules(ruleRaw.Data)


### PR DESCRIPTION
Changelog:
- Expression with result of `nil` will no be added to working memory.
- Use RWMutex instead of Mutex.

Bnechmark result : 
```
goos: windows
goarch: amd64
pkg: github.com/hooqtv/fished
BenchmarkFullRemake-4              20000             72855 ns/op           26368 B/op        391 allocs/op
BenchmarkResetFacts-4             300000              4650 ns/op             608 B/op          4 allocs/op
BenchmarkRun1-4                   200000              6712 ns/op             272 B/op          2 allocs/op
BenchmarkRun1Cached-4             200000              6372 ns/op             272 B/op          2 allocs/op
BenchmarkRun4-4                   200000              9075 ns/op             272 B/op          2 allocs/op
BenchmarkRun4Cached-4             200000              9180 ns/op             272 B/op          2 allocs/op
PASS
ok      github.com/hooqtv/fished        25.753s
```