### PR TITLE
Re write fished engine.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,14 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
+  name = "github.com/patrickmn/go-cache"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
+  version = "v2.1.0"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -63,6 +71,7 @@
   input-imports = [
     "github.com/json-iterator/go",
     "github.com/knetic/govaluate",
+    "github.com/patrickmn/go-cache",
     "github.com/stretchr/testify/assert",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/json-iterator/go"
-  version = "1.0.6"
+  version = "1.1.5"
 
 [[constraint]]
   name = "github.com/knetic/govaluate"
@@ -39,4 +39,8 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.1"
+  version = "1.2.2"
+
+[[constraint]]
+  name = "github.com/patrickmn/go-cache"
+  version = "2.1.0"

--- a/engine.go
+++ b/engine.go
@@ -40,8 +40,8 @@ type (
 	// Runtime is an struct for each time Engine.Run() is called
 	Runtime struct {
 		Facts      map[string]interface{}
-		JobCh      chan Job
-		ResultCh   chan EvalResult
+		JobCh      chan *Job
+		ResultCh   chan *EvalResult
 		UsedRule   map[int]struct{}
 		FactsMutex sync.RWMutex
 		WorkerWg   sync.WaitGroup
@@ -168,8 +168,8 @@ func (e *Engine) Run(target string, worker int) (interface{}, []error) {
 
 	r := &Runtime{
 		Facts:    facts,
-		JobCh:    make(chan Job, len(e.Rules)),
-		ResultCh: make(chan EvalResult, len(e.Rules)),
+		JobCh:    make(chan *Job, len(e.Rules)),
+		ResultCh: make(chan *EvalResult, len(e.Rules)),
 		UsedRule: make(map[int]struct{}),
 	}
 
@@ -236,7 +236,7 @@ func (e *Engine) Run(target string, worker int) (interface{}, []error) {
 				}
 			}
 
-			j := Job{
+			j := &Job{
 				ParsedExpression: parsedExpression.(*govaluate.EvaluableExpression),
 				Output:           rule.Output,
 			}
@@ -272,8 +272,8 @@ func (e *Engine) Run(target string, worker int) (interface{}, []error) {
 }
 
 // Evaluate will evaluate each job in runtime
-func (r *Runtime) Evaluate(job Job, result chan<- EvalResult) {
-	evalResult := EvalResult{
+func (r *Runtime) Evaluate(job *Job, result chan<- *EvalResult) {
+	evalResult := &EvalResult{
 		Key: job.Output,
 	}
 

--- a/engine.go
+++ b/engine.go
@@ -1,222 +1,294 @@
 package fished
 
 import (
+	"runtime"
 	"sync"
+	"time"
 
 	"github.com/knetic/govaluate"
+	"github.com/patrickmn/go-cache"
 )
 
-// Config ...
-type Config struct {
-	Worker         int
-	WorkerPoolSize int
-	Cache          bool
-}
+var (
+	//DefaultTarget is the default target facts
+	DefaultTarget = "result_end"
 
-// Engine ...
-type Engine struct {
-	Rules        []Rule
-	rf           map[string]govaluate.ExpressionFunction
-	Jobs         chan int
-	Config       *Config
-	work         sync.WaitGroup
-	wmMutex      sync.RWMutex
-	runMutex     sync.Mutex
-	factsMutex   sync.RWMutex
-	err          []error
-	wm           map[string]interface{}
-	workingRules map[string][]int
-}
+	// DefaultWorker is the default worker for Engine
+	DefaultWorker = 0
+)
 
-// Rule ...
-type Rule struct {
-	Output      string   `json:"output"`
-	Input       []string `json:"input"`
-	Expression  string   `json:"expression"`
-	ee          *govaluate.EvaluableExpression
-	facts       map[string]interface{}
-	result      interface{}
-	hasExecuted bool
-}
-
-// RuleRaw ...
-type RuleRaw struct {
-	Data []Rule `json:"data"`
-}
-
-// RuleFunction ...
-type RuleFunction func(arguments ...interface{}) (interface{}, error)
-
-var workerPoolSize = 10
-
-// New ...
-func New(c *Config) *Engine {
-	cfg := &Config{
-		Worker:         1,
-		WorkerPoolSize: 20,
-		Cache:          false,
+type (
+	// Engine core of the machine
+	Engine struct {
+		InitialFacts  map[string]interface{}
+		Rules         []Rule
+		RuleFunctions map[string]govaluate.ExpressionFunction
+		RuleCache     *cache.Cache
+		RunLock       sync.RWMutex
 	}
-	if c != nil {
-		if c.Worker > 0 {
-			cfg.Worker = c.Worker
+
+	// Rule is struct for rule in fished
+	Rule struct {
+		Input      []string `json:"input"`
+		Output     string   `json:"output"`
+		Expression string   `json:"expression"`
+	}
+
+	// RuleFunction if type defined for rule function
+	RuleFunction func(...interface{}) (interface{}, error)
+
+	// Runtime is an struct for each time Engine.Run() is called
+	Runtime struct {
+		Facts      map[string]interface{}
+		JobCh      chan Job
+		ResultCh   chan EvalResult
+		UsedRule   map[int]struct{}
+		FactsMutex sync.RWMutex
+		WorkerWg   sync.WaitGroup
+	}
+
+	// Job struct
+	Job struct {
+		Output           string
+		ParsedExpression *govaluate.EvaluableExpression
+	}
+
+	// EvalResult is evaluation Result
+	EvalResult struct {
+		Key   string
+		Value interface{}
+		Error error
+	}
+)
+
+// New will create new engine
+func New() *Engine {
+	c := cache.New(24*time.Hour, 1*time.Hour)
+
+	return &Engine{
+		RuleCache: c,
+	}
+}
+
+// Set all of engine attibutes in one single function
+func (e *Engine) Set(facts map[string]interface{}, rules []Rule, ruleFunction map[string]RuleFunction) error {
+	var err error
+
+	err = e.SetFacts(facts)
+	if err != nil {
+		return err
+	}
+
+	err = e.SetRules(rules)
+	if err != nil {
+		return err
+	}
+
+	err = e.SetRuleFunctions(ruleFunction)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetFacts will set current engine with initial facts (replace the old one)
+func (e *Engine) SetFacts(facts map[string]interface{}) error {
+	e.RunLock.Lock()
+	defer e.RunLock.Unlock()
+	e.InitialFacts = make(map[string]interface{})
+
+	for key, value := range facts {
+		e.InitialFacts[key] = value
+	}
+	return nil
+}
+
+// SetRules will set current engine with rules
+func (e *Engine) SetRules(rules []Rule) error {
+	e.RunLock.Lock()
+	defer e.RunLock.Unlock()
+	e.Rules = make([]Rule, len(rules))
+	copy(e.Rules, rules)
+	e.RuleCache.Flush()
+	return nil
+}
+
+// SetRuleFunctions will set current engine with Expression Functions
+func (e *Engine) SetRuleFunctions(ruleFunctions map[string]RuleFunction) error {
+	e.RunLock.Lock()
+	defer e.RunLock.Unlock()
+	e.RuleFunctions = make(map[string]govaluate.ExpressionFunction)
+
+	for key, value := range ruleFunctions {
+		e.RuleFunctions[key] = govaluate.ExpressionFunction(value)
+	}
+	return nil
+}
+
+// RunDefault will execute run with default parameneter
+func (e *Engine) RunDefault() (interface{}, []error) {
+	return e.Run(DefaultTarget, DefaultWorker)
+}
+
+// Run will execute rule and facts to get the result
+func (e *Engine) Run(target string, worker int) (interface{}, []error) {
+	var workerSize int
+	var endTarget string
+	var errs []error
+
+	e.RunLock.RLock()
+	defer e.RunLock.RUnlock()
+
+	if target == DefaultTarget {
+		endTarget = DefaultTarget
+	} else {
+		endTarget = target
+	}
+
+	if worker == DefaultWorker {
+		numCPU := runtime.NumCPU()
+		if numCPU <= 2 {
+			workerSize = 1
+		} else {
+			workerSize = runtime.NumCPU() - 1
 		}
-		if c.WorkerPoolSize > (0 + cfg.Worker) {
-			cfg.WorkerPoolSize = c.WorkerPoolSize
-		}
-		cfg.Cache = c.Cache
+	} else {
+		workerSize = worker
 	}
-	e := &Engine{
-		Config: cfg,
-		err:    []error{},
+
+	if workerSize <= 0 {
+		workerSize = 1
 	}
-	return e
-}
 
-// SetFacts ...
-func (e *Engine) SetFacts(f map[string]interface{}) {
-	e.wm = make(map[string]interface{})
-	for i, v := range f {
-		e.wm[i] = v
+	facts := make(map[string]interface{})
+	for key, value := range e.InitialFacts {
+		facts[key] = value
 	}
-}
 
-// SetRules ...
-func (e *Engine) SetRules(r []Rule) {
-	e.Rules = make([]Rule, len(r))
-	copy(e.Rules, r)
+	r := &Runtime{
+		Facts:    facts,
+		JobCh:    make(chan Job, len(e.Rules)),
+		ResultCh: make(chan EvalResult, len(e.Rules)),
+		UsedRule: make(map[int]struct{}),
+	}
 
-	e.workingRules = make(map[string][]int)
-	for i, rule := range r {
-		for _, input := range rule.Input {
-			if e.workingRules[input] == nil {
-				e.workingRules[input] = []int{i}
-			} else {
-				e.workingRules[input] = append(e.workingRules[input], i)
+	r.WorkerWg.Add(workerSize)
+	for i := 0; i < workerSize; i++ {
+		go func() {
+			defer r.WorkerWg.Done()
+			for job := range r.JobCh {
+				r.Evaluate(job, r.ResultCh)
 			}
-		}
-	}
-}
-
-// SetRuleFunction ...
-func (e *Engine) SetRuleFunction(rf map[string]RuleFunction) {
-	e.rf = make(map[string]govaluate.ExpressionFunction)
-	for i, f := range rf {
-		e.rf[i] = govaluate.ExpressionFunction(f)
-	}
-}
-
-// Run ...
-func (e *Engine) Run(target ...string) (interface{}, []error) {
-	e.runMutex.Lock()
-	defer e.runMutex.Unlock()
-
-	e.Jobs = make(chan int, e.Config.WorkerPoolSize)
-
-	var wg sync.WaitGroup
-
-	e.createAgenda()
-	for i := 0; i < e.Config.Worker; i++ {
-		wg.Add(1)
-		go e.worker(&wg)
+		}()
 	}
 
-	e.watcher()
-	wg.Wait()
-	res := "result_end"
-	if len(target) == 1 {
-		res = target[0]
-	}
-
-	return e.wm[res], e.err
-}
-
-func (e *Engine) watcher() {
-	e.work.Wait()
-	close(e.Jobs)
-
-	for _, rule := range e.Rules {
-		rule.hasExecuted = false
-	}
-}
-
-func (e *Engine) worker(wg *sync.WaitGroup) {
-	for job := range e.Jobs {
-		e.eval(job)
-		e.work.Done()
-	}
-	wg.Done()
-}
-
-// eval will evaluate current rule.
-func (e *Engine) eval(index int) {
-	if e.Rules[index].Output != "" && !e.Rules[index].hasExecuted {
-		e.Rules[index].hasExecuted = true
-		if e.Rules[index].ee == nil {
-			re, err := govaluate.NewEvaluableExpressionWithFunctions(e.Rules[index].Expression, e.rf)
-			if err != nil {
-				e.err = append(e.err, err)
-				return
-			}
-			e.Rules[index].ee = re
-		}
-
-		if e.Rules[index].result == nil || !e.Config.Cache {
-			e.factsMutex.RLock()
-			result, err := e.Rules[index].ee.Evaluate(e.Rules[index].facts)
-			e.factsMutex.RUnlock()
-			if err != nil {
-				e.err = append(e.err, err)
-				return
+	for {
+		var jobLength int
+		var parseRuleError bool
+		for i := range e.Rules {
+			// Check if the rule already been executed
+			if _, ok := r.UsedRule[i]; ok {
+				continue
 			}
 
-			if result != nil {
-				e.Rules[index].result = result
-			}
-		}
+			// copy rule into context
+			rule := e.Rules[i]
 
-		if e.Rules[index].result != nil {
-			e.wmMutex.Lock()
-			e.wm[e.Rules[index].Output] = e.Rules[index].result
-			e.wmMutex.Unlock()
-			e.updateAgenda(e.Rules[index].Output)
-		}
-	}
-}
-
-// Add jobs base on current working memory attribute
-func (e *Engine) updateAgenda(input string) {
-	rules := e.workingRules[input]
-	for _, i := range rules {
-		rule := e.Rules[i]
-		validInput := 0
-		e.wmMutex.RLock()
-		for attribute, value := range e.wm {
-			for _, input := range rule.Input {
-				if input == attribute {
-					validInput++
-					e.factsMutex.Lock()
-					if rule.facts == nil {
-						rule.facts = make(map[string]interface{})
+			// Verify if rule has met input requirement
+			inputLen := len(rule.Input)
+			if inputLen > 0 {
+				var ValidInput int
+				for _, input := range rule.Input {
+					if _, ok := r.Facts[input]; ok {
+						ValidInput++
 					}
-					if rule.facts[attribute] == nil || !e.Config.Cache {
-						rule.facts[attribute] = value
-					}
-					e.factsMutex.Unlock()
+				}
+				if inputLen != ValidInput {
+					continue
 				}
 			}
+
+			// Check cache for parsed rule
+			parsedExpression, ok := e.RuleCache.Get(rule.Expression)
+
+			// if not exist in cache then parse rule
+			if !ok {
+				var err error
+				parsedExpression, err = govaluate.NewEvaluableExpressionWithFunctions(rule.Expression, e.RuleFunctions)
+				if err != nil {
+					if errs == nil {
+						errs = make([]error, 0)
+					}
+					errs = append(errs, err)
+					parseRuleError = true
+					break
+				}
+
+				err = e.RuleCache.Add(rule.Expression, parsedExpression, cache.DefaultExpiration)
+				if err != nil {
+					if errs == nil {
+						errs = make([]error, 0)
+					}
+					errs = append(errs, err)
+					parseRuleError = true
+					break
+				}
+			}
+
+			j := Job{
+				ParsedExpression: parsedExpression.(*govaluate.EvaluableExpression),
+				Output:           rule.Output,
+			}
+			r.UsedRule[i] = struct{}{}
+			r.JobCh <- j
+			jobLength++
 		}
-		e.wmMutex.RUnlock()
-		if validInput == len(rule.Input) && validInput != 0 {
-			e.work.Add(1)
-			e.Jobs <- i
+
+		if jobLength == 0 || parseRuleError {
+			r.PrepareExit()
+			break
 		}
-		e.Rules[i] = rule
+
+		for jobs := 0; jobs < jobLength; jobs++ {
+			evalResult := <-r.ResultCh
+			if evalResult.Error != nil {
+				if errs == nil {
+					errs = make([]error, 0)
+				}
+				errs = append(errs, evalResult.Error)
+				continue
+			}
+			if evalResult.Value != nil {
+				r.FactsMutex.Lock()
+				r.Facts[evalResult.Key] = evalResult.Value
+				r.FactsMutex.Unlock()
+			}
+		}
 	}
+
+	r.WorkerWg.Wait()
+	return r.Facts[endTarget], errs
 }
 
-// initialize jobs
-func (e *Engine) createAgenda() {
-	for attribute := range e.wm {
-		e.updateAgenda(attribute)
+// Evaluate will evaluate each job in runtime
+func (r *Runtime) Evaluate(job Job, result chan<- EvalResult) {
+	evalResult := EvalResult{
+		Key: job.Output,
 	}
+
+	r.FactsMutex.RLock()
+	res, err := job.ParsedExpression.Evaluate(r.Facts)
+	r.FactsMutex.RUnlock()
+	if err != nil {
+		evalResult.Error = err
+	}
+	evalResult.Value = res
+	result <- evalResult
+}
+
+// PrepareExit the runtime and close
+func (r *Runtime) PrepareExit() {
+	close(r.JobCh)
+	close(r.ResultCh)
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,253 +1,169 @@
 package fished
 
 import (
-	"errors"
 	"io/ioutil"
+	"os"
+	"runtime"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
+	"github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 )
 
-var c = &Config{
-	Worker:         1,
-	WorkerPoolSize: 20,
-	Cache:          false,
-}
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func TestRun(t *testing.T) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
-	res, errs := e.Run()
-
-	assert.Equal(t, true, res, "should be true")
-	assert.Equal(t, 0, len(errs), "no errors")
-}
-
-func TestRunBlockedPath(t *testing.T) {
-	raw, _ := ioutil.ReadFile("./test/tc5.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
-	res, errs := e.Run()
-
-	assert.Equal(t, nil, res, "should be nil")
-	assert.Equal(t, 0, len(errs), "no errors")
-}
-
-func TestRunNil(t *testing.T) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	e := New(nil)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
-	res, errs := e.Run()
-
-	assert.Equal(t, true, res, "should be true")
-	assert.Equal(t, 0, len(errs), "no errors")
-}
-
-func TestRunInvalidRule(t *testing.T) {
-	raw, _ := ioutil.ReadFile("./test/tc2.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	e.SetFacts(f)
-	res, errs := e.Run()
-
-	assert.Equal(t, nil, res, "should be nil")
-	assert.Equal(t, 1, len(errs), "no errors")
-}
-
-func TestRunSpecifyEndResult(t *testing.T) {
-	raw, _ := ioutil.ReadFile("./test/tc3.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
-	res, errs := e.Run("isEligible")
-
-	assert.Equal(t, true, res, "should be true")
-	assert.Equal(t, 0, len(errs), "no errors")
-}
-
-func TestRuleFunction(t *testing.T) {
-	raw, _ := ioutil.ReadFile("./test/tc4.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	e := New(c)
-	f := make(map[string]interface{})
-	f["example"] = "random"
-	rf := make(map[string]RuleFunction)
-	rf["set"] = func(arguments ...interface{}) (interface{}, error) {
-		if len(arguments) == 1 {
-			return arguments[0], nil
-		}
-		return nil, errors.New("Lack of arguments")
+	tc := []struct {
+		Name           string
+		TCFile         string
+		Facts          map[string]interface{}
+		RuleFunction   map[string]RuleFunction
+		Target         string
+		Worker         int
+		ExpectedResult interface{}
+		IsError        bool
+	}{
+		{
+			Name:   "test",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+		},
 	}
-	e.SetRules(ruleRaw.Data)
-	e.SetFacts(f)
-	e.SetRuleFunction(rf)
 
-	res, errs := e.Run()
+	for _, test := range tc {
+		t.Run(test.Name, func(t *testing.T) {
+			// Open our jsonFile
+			jsonFile, err := os.Open(test.TCFile)
+			// if we os.Open returns an error then handle it
+			if !assert.Nil(t, err) {
+				return
+			}
 
-	assert.Equal(t, true, res, "should be true")
-	assert.Equal(t, 0, len(errs), "no errors")
-}
+			// defer the closing of our jsonFile so that we can parse it later on
+			defer jsonFile.Close()
 
-func BenchmarkFullRemake(b *testing.B) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
+			// read our opened xmlFile as a byte array.
+			byteValue, _ := ioutil.ReadAll(jsonFile)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
+			var ruleMap struct {
+				Data []Rule `json:"data"`
+			}
 
-	for i := 0; i < b.N; i++ {
-		e := New(c)
-		e.SetRules(ruleRaw.Data)
-		f := make(map[string]interface{})
-		f["account_partner"] = "hello"
-		f["account_region"] = "ID"
-		e.SetFacts(f)
-		e.Run()
+			err = json.Unmarshal(byteValue, &ruleMap)
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			e := New()
+			e.Set(test.Facts, ruleMap.Data, test.RuleFunction)
+			res, errs := e.Run(test.Target, test.Worker)
+			if test.IsError {
+				assert.NotNil(t, errs)
+			} else {
+				if assert.NotNil(t, res) {
+					assert.Equal(t, test.ExpectedResult, res)
+				}
+			}
+		})
 	}
 }
 
-func BenchmarkResetFacts(b *testing.B) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	for i := 0; i < b.N; i++ {
-		f := make(map[string]interface{})
-		f["account_partner"] = "hello"
-		f["account_region"] = "ID"
-		e.SetFacts(f)
-		e.Run()
+func BenchmarkRun(b *testing.B) {
+	tc := []struct {
+		Name           string
+		TCFile         string
+		Facts          map[string]interface{}
+		RuleFunction   map[string]RuleFunction
+		Target         string
+		Worker         int
+		ExpectedResult interface{}
+		IsError        bool
+	}{
+		{
+			Name:   "DefaultWorker",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "1 Worker",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         1,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "Equal CPU Count",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         runtime.NumCPU(),
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "Double CPU Count",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         runtime.NumCPU() * 2,
+			Target:         DefaultTarget,
+		},
 	}
-}
 
-func BenchmarkRun1(b *testing.B) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
+	for _, test := range tc {
+		b.Run(test.Name, func(b *testing.B) {
+			// Open our jsonFile
+			jsonFile, _ := os.Open(test.TCFile)
+			// if we os.Open returns an error then handle it
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
+			// defer the closing of our jsonFile so that we can parse it later on
+			defer jsonFile.Close()
 
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
+			// read our opened xmlFile as a byte array.
+			byteValue, _ := ioutil.ReadAll(jsonFile)
 
-	for i := 0; i < b.N; i++ {
-		e.Run()
-	}
-}
+			var ruleMap struct {
+				Data []Rule `json:"data"`
+			}
 
-func BenchmarkRun1Cached(b *testing.B) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
+			json.Unmarshal(byteValue, &ruleMap)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	c.Cache = true
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
-
-	for i := 0; i < b.N; i++ {
-		e.Run()
-	}
-}
-
-func BenchmarkRun4(b *testing.B) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	c.Worker = 4
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
-
-	for i := 0; i < b.N; i++ {
-		e.Run()
-	}
-}
-
-func BenchmarkRun4Cached(b *testing.B) {
-	raw, _ := ioutil.ReadFile("./test/tc1.json")
-
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	var ruleRaw RuleRaw
-	json.Unmarshal(raw, &ruleRaw)
-
-	c.Worker = 4
-	c.Cache = true
-	e := New(c)
-	e.SetRules(ruleRaw.Data)
-	f := make(map[string]interface{})
-	f["account_partner"] = "hello"
-	f["account_region"] = "ID"
-	e.SetFacts(f)
-
-	for i := 0; i < b.N; i++ {
-		e.Run()
+			e := New()
+			e.Set(test.Facts, ruleMap.Data, test.RuleFunction)
+			for i := 0; i < b.N; i++ {
+				e.Run(test.Target, test.Worker)
+			}
+		})
 	}
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -24,7 +24,7 @@ func TestRun(t *testing.T) {
 		IsError        bool
 	}{
 		{
-			Name:   "test",
+			Name:   "tc1 normal usecase",
 			TCFile: "./test/tc1.json",
 			Facts: map[string]interface{}{
 				"account_partner": "hello",
@@ -35,6 +35,48 @@ func TestRun(t *testing.T) {
 			IsError:        false,
 			Worker:         DefaultWorker,
 			Target:         DefaultTarget,
+		},
+		{
+			Name:   "tc2 unfinished ruleset",
+			TCFile: "./test/tc2.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: nil,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "tc3 custom end target",
+			TCFile: "./test/tc3.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         "isEligible",
+		},
+		{
+			Name:   "tc4 rule function",
+			TCFile: "./test/tc4.json",
+			Facts: map[string]interface{}{
+				"example": "killer",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+			RuleFunction: map[string]RuleFunction{
+				"set": func(args ...interface{}) (interface{}, error) {
+					return args[0], nil
+				},
+			},
 		},
 	}
 
@@ -68,9 +110,118 @@ func TestRun(t *testing.T) {
 			if test.IsError {
 				assert.NotNil(t, errs)
 			} else {
-				if assert.NotNil(t, res) {
-					assert.Equal(t, test.ExpectedResult, res)
-				}
+				assert.Equal(t, test.ExpectedResult, res)
+			}
+		})
+	}
+}
+
+func TestDoubleRun(t *testing.T) {
+	tc := []struct {
+		Name           string
+		TCFile         string
+		Facts          map[string]interface{}
+		RuleFunction   map[string]RuleFunction
+		Target         string
+		Worker         int
+		ExpectedResult interface{}
+		IsError        bool
+	}{
+		{
+			Name:   "tc1 normal usecase",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "tc2 unfinished ruleset",
+			TCFile: "./test/tc2.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: nil,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "test",
+			TCFile: "./test/tc3.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         "isEligible",
+		},
+		{
+			Name:   "tc4 rule function",
+			TCFile: "./test/tc4.json",
+			Facts: map[string]interface{}{
+				"example": "killer",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+			RuleFunction: map[string]RuleFunction{
+				"set": func(args ...interface{}) (interface{}, error) {
+					return args[0], nil
+				},
+			},
+		},
+	}
+
+	for _, test := range tc {
+		t.Run(test.Name, func(t *testing.T) {
+			// Open our jsonFile
+			jsonFile, err := os.Open(test.TCFile)
+			// if we os.Open returns an error then handle it
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			// defer the closing of our jsonFile so that we can parse it later on
+			defer jsonFile.Close()
+
+			// read our opened xmlFile as a byte array.
+			byteValue, _ := ioutil.ReadAll(jsonFile)
+
+			var ruleMap struct {
+				Data []Rule `json:"data"`
+			}
+
+			err = json.Unmarshal(byteValue, &ruleMap)
+			if !assert.Nil(t, err) {
+				return
+			}
+
+			e := New()
+			e.Set(test.Facts, ruleMap.Data, test.RuleFunction)
+			res, errs := e.Run(test.Target, test.Worker)
+			if test.IsError {
+				assert.NotNil(t, errs)
+			} else {
+				assert.Equal(t, test.ExpectedResult, res)
+			}
+
+			res, errs = e.Run(test.Target, test.Worker)
+			if test.IsError {
+				assert.NotNil(t, errs)
+			} else {
+				assert.Equal(t, test.ExpectedResult, res)
 			}
 		})
 	}
@@ -139,6 +290,22 @@ func BenchmarkRun(b *testing.B) {
 			Worker:         runtime.NumCPU() * 2,
 			Target:         DefaultTarget,
 		},
+		{
+			Name:   "DefaultWorker w/ rf",
+			TCFile: "./test/tc4.json",
+			Facts: map[string]interface{}{
+				"example": "killer",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+			RuleFunction: map[string]RuleFunction{
+				"set": func(args ...interface{}) (interface{}, error) {
+					return args[0], nil
+				},
+			},
+		},
 	}
 
 	for _, test := range tc {
@@ -162,6 +329,114 @@ func BenchmarkRun(b *testing.B) {
 			e := New()
 			e.Set(test.Facts, ruleMap.Data, test.RuleFunction)
 			for i := 0; i < b.N; i++ {
+				e.Run(test.Target, test.Worker)
+			}
+		})
+	}
+}
+
+func BenchmarkRunFullRemakeEngine(b *testing.B) {
+	tc := []struct {
+		Name           string
+		TCFile         string
+		Facts          map[string]interface{}
+		RuleFunction   map[string]RuleFunction
+		Target         string
+		Worker         int
+		ExpectedResult interface{}
+		IsError        bool
+	}{
+		{
+			Name:   "DefaultWorker",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "1 Worker",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         1,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "Equal CPU Count",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         runtime.NumCPU(),
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "Double CPU Count",
+			TCFile: "./test/tc1.json",
+			Facts: map[string]interface{}{
+				"account_partner": "hello",
+				"account_region":  "ID",
+				"flight_type":     "free",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         runtime.NumCPU() * 2,
+			Target:         DefaultTarget,
+		},
+		{
+			Name:   "DefaultWorker w/ rf",
+			TCFile: "./test/tc4.json",
+			Facts: map[string]interface{}{
+				"example": "killer",
+			},
+			ExpectedResult: true,
+			IsError:        false,
+			Worker:         DefaultWorker,
+			Target:         DefaultTarget,
+			RuleFunction: map[string]RuleFunction{
+				"set": func(args ...interface{}) (interface{}, error) {
+					return args[0], nil
+				},
+			},
+		},
+	}
+
+	for _, test := range tc {
+		b.Run(test.Name, func(b *testing.B) {
+			// Open our jsonFile
+			jsonFile, _ := os.Open(test.TCFile)
+			// if we os.Open returns an error then handle it
+
+			// defer the closing of our jsonFile so that we can parse it later on
+			defer jsonFile.Close()
+
+			// read our opened xmlFile as a byte array.
+			byteValue, _ := ioutil.ReadAll(jsonFile)
+
+			var ruleMap struct {
+				Data []Rule `json:"data"`
+			}
+
+			json.Unmarshal(byteValue, &ruleMap)
+
+			for i := 0; i < b.N; i++ {
+				e := New()
+				e.Set(test.Facts, ruleMap.Data, test.RuleFunction)
 				e.Run(test.Target, test.Worker)
 			}
 		})


### PR DESCRIPTION
### Summary 

- Improve handling goroutine
- Improve Worker allocation (base on number of CPU available)
- Improve test cases runtime
- Improve benchmark runtime
- Add cache to parsed rule

### Test results
```
ok  	github.com/hooqtv/fished	0.005s	coverage: 85.8% of statements
Success: Tests passed.
```

### Benchmark result

**Run Benchmark (use the same engine)**
```
goos: linux
goarch: amd64
pkg: github.com/hooqtv/fished
BenchmarkRun/DefaultWorker-4         	  100000	     12958 ns/op	    1409 B/op	      27 allocs/op
BenchmarkRun/1_Worker-4              	  200000	     10982 ns/op	    1408 B/op	      27 allocs/op
BenchmarkRun/Equal_CPU_Count-4       	  100000	     13827 ns/op	    1409 B/op	      27 allocs/op
BenchmarkRun/Double_CPU_Count-4      	  100000	     17314 ns/op	    1409 B/op	      27 allocs/op
BenchmarkRun/DefaultWorker_w/_rf-4   	  100000	     10369 ns/op	    1120 B/op	      20 allocs/op
PASS
ok  	github.com/hooqtv/fished	8.332s
Success: Benchmarks passed.
```

**Benchmark Run with new engine each run**
```
goos: linux
goarch: amd64
pkg: github.com/hooqtv/fished
BenchmarkRunFullRemakeEngine/DefaultWorker-4         	   20000	     73392 ns/op	   19379 B/op	     302 allocs/op
BenchmarkRunFullRemakeEngine/1_Worker-4              	   20000	     58113 ns/op	   19375 B/op	     302 allocs/op
BenchmarkRunFullRemakeEngine/Equal_CPU_Count-4       	   20000	     70231 ns/op	   19380 B/op	     302 allocs/op
BenchmarkRunFullRemakeEngine/Double_CPU_Count-4      	   20000	     75474 ns/op	   19381 B/op	     302 allocs/op
BenchmarkRunFullRemakeEngine/DefaultWorker_w/_rf-4   	   50000	     32468 ns/op	    8253 B/op	     131 allocs/op
PASS
ok  	github.com/hooqtv/fished	10.315s
Success: Benchmarks passed.
```

Notes : `1 worker` seems to be faster than `DefaultWorker` but we use capability of executing rule in **parallel**.
